### PR TITLE
fix: bwcx-api-client/generator does not generate optional parameters for client functions, regardless of the value of opts.req.

### DIFF
--- a/packages/bwcx-api-client/src/generator.ts
+++ b/packages/bwcx-api-client/src/generator.ts
@@ -295,7 +295,7 @@ ${baseIndent}}`;
     }
  * @returns {${this.getReqOrRespStr(opts.resp)}} The response data (RespDTO).
  */
-public async ${opts.name}(req${opts.req ? '' : '?'}: ${this.getReqOrRespStr(opts.req)}${
+public async ${opts.name}(req: ${this.getReqOrRespStr(opts.req)}${
       this.config.enableExtraReqOptions ? `, opts?: T` : ''
     }): Promise<${this.getReqOrRespStr(opts.resp)}> {
   return this._r(this._rArgs.${this.nta(this.aIndex)}(req${

--- a/packages/bwcx-api-client/src/generator.ts
+++ b/packages/bwcx-api-client/src/generator.ts
@@ -295,7 +295,7 @@ ${baseIndent}}`;
     }
  * @returns {${this.getReqOrRespStr(opts.resp)}} The response data (RespDTO).
  */
-public async ${opts.name}(req: ${this.getReqOrRespStr(opts.req)}${
+public async ${opts.name}(req${opts.req ? '' : '?'}: ${this.getReqOrRespStr(opts.req)}${
       this.config.enableExtraReqOptions ? `, opts?: T` : ''
     }): Promise<${this.getReqOrRespStr(opts.resp)}> {
   return this._r(this._rArgs.${this.nta(this.aIndex)}(req${
@@ -334,7 +334,7 @@ ${opts.reqParamSource.body.map((i) => `  formData.append('${i}', req.${i});`).jo
     }
     const reqStr = this.getReqOrRespStr(opts.req);
     const respStr = this.getReqOrRespStr(opts.resp);
-    return `${this.nta(this.aIndex)}: (req: ${reqStr}${
+    return `${this.nta(this.aIndex)}: (req${opts.req ? '' : '?'}: ${reqStr}${
       this.config.enableExtraReqOptions ? `, opts?: any` : ''
     }) => {
   ${formDataGen}return {


### PR DESCRIPTION
optional parameters will lead to ApiRequestArgs type error: 
Argument of type 'null | undefined' is not assignable to parameter of type 'null'.
  Type 'undefined' is not assignable to type 'null'.ts(2345)

```ts
...
  public async GetServiceList(req?: null, opts?: T): Promise<GetServiceListRespDto> {
    return this._r(this._rArgs.a(req, opts)).then((resp) => this._rp.pat(GetServiceListRespDto, resp));
  }

  private _rArgs = {
    a: (req: null, opts?: any) => {
      return {
        method: 'POST' as AllowedRequestMethod,
        url: this._uf('/ngi/GetServiceList', {
          param: {},
          query: {},
        }),
        data: {},
        extraOpts: opts,
        metadata: {
          name: 'GetServiceList',
          method: 'POST',
          path: '/ngi/GetServiceList',
          req: null as null,
          resp: GetServiceListRespDto,
        },
      };
    },
}
...
```